### PR TITLE
Relation One can now be accessed by Transphporm

### DIFF
--- a/maphper/relation/one.php
+++ b/maphper/relation/one.php
@@ -36,6 +36,10 @@ class One implements \Maphper\Relation {
 		if ($this->lazyLoad() == null) return '';
 		return call_user_func_array([$this->lazyLoad(), $func], $args);
 	}
+
+	public function __isset($name) {
+		return isset($this->lazyLoad()->$name);
+	}
 	
 	public function __get($name) {
 		if ($this->lazyLoad()) return $this->lazyLoad()->$name;


### PR DESCRIPTION
Since Transphporm checks if the property isset before accessing it then __isset must be defined